### PR TITLE
2.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.kieronquinn.app.discoverkiller"
         minSdkVersion 29
         targetSdkVersion 31
-        versionCode 21
-        versionName "2.1"
+        versionCode 22
+        versionName "2.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -68,7 +68,7 @@ dependencies {
     //Stubs for hidden APIs used by overlay. Shouldn't be included in APK.
     compileOnly project(':systemstubs')
 
-    implementation "androidx.fragment:fragment-ktx:1.4.0-alpha06"
+    implementation "androidx.fragment:fragment-ktx:1.4.0-alpha07"
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
 

--- a/app/release/output-metadata.json
+++ b/app/release/output-metadata.json
@@ -11,8 +11,8 @@
       "type": "SINGLE",
       "filters": [],
       "attributes": [],
-      "versionCode": 2,
-      "versionName": "2.0",
+      "versionCode": 22,
+      "versionName": "2.2",
       "outputFile": "app-release.apk"
     }
   ],

--- a/app/src/main/java/com/google/android/libraries/gsa/overlay/overlay/BaseOverlay.kt
+++ b/app/src/main/java/com/google/android/libraries/gsa/overlay/overlay/BaseOverlay.kt
@@ -103,23 +103,4 @@ abstract class BaseOverlay<T: ViewBinding>(context: Context, private val viewBin
         return lifecycleRegistry
     }
 
-    /**
-     *  The standard [Window.setNavigationBarColor] and [Window.setStatusBarColor] don't work for
-     *  this embedded window so we make them invisible manually
-     */
-    internal fun View.removeStatusNavBackgroundOnPreDraw() = apply {
-        doOnPreDraw {
-            val statusBarBackground = it.findViewById<View>(android.R.id.statusBarBackground)
-            statusBarBackground?.run {
-                visibility = View.INVISIBLE
-                alpha = 0f
-            }
-            val navigationBarBackground = it.findViewById<View>(android.R.id.navigationBarBackground)
-            navigationBarBackground?.run {
-                visibility = View.INVISIBLE
-                alpha = 0f
-            }
-        }
-    }
-
 }

--- a/app/src/main/java/com/kieronquinn/app/discoverkiller/DiscoverKiller.kt
+++ b/app/src/main/java/com/kieronquinn/app/discoverkiller/DiscoverKiller.kt
@@ -18,6 +18,8 @@ import com.kieronquinn.app.discoverkiller.ui.screens.settings.container.Settings
 import com.kieronquinn.app.discoverkiller.ui.screens.settings.container.SettingsViewModelImpl
 import com.kieronquinn.app.discoverkiller.ui.screens.settings.dumplogs.SettingsDumpLogsBottomSheetViewModel
 import com.kieronquinn.app.discoverkiller.ui.screens.settings.dumplogs.SettingsDumpLogsBottomSheetViewModelImpl
+import com.kieronquinn.app.discoverkiller.ui.screens.settings.error.errorignore.ErrorIgnoreBottomSheetViewModel
+import com.kieronquinn.app.discoverkiller.ui.screens.settings.error.errorignore.ErrorIgnoreBottomSheetViewModelImpl
 import com.kieronquinn.app.discoverkiller.utils.AppIconRequestHandler
 import com.kieronquinn.monetcompat.core.MonetCompat
 import com.squareup.picasso.Picasso
@@ -46,6 +48,7 @@ class DiscoverKiller : Application() {
             viewModel<SettingsAppPickerViewModel> { SettingsAppPickerViewModelImpl(get()) }
             viewModel<SettingsBackgroundPickerViewModel> { SettingsBackgroundPickerViewModelImpl(get()) }
             viewModel<SettingsDumpLogsBottomSheetViewModel> { SettingsDumpLogsBottomSheetViewModelImpl(get(), get()) }
+            viewModel<ErrorIgnoreBottomSheetViewModel> { ErrorIgnoreBottomSheetViewModelImpl(get()) }
         }
     }
 

--- a/app/src/main/java/com/kieronquinn/app/discoverkiller/components/settings/Settings.kt
+++ b/app/src/main/java/com/kieronquinn/app/discoverkiller/components/settings/Settings.kt
@@ -20,6 +20,7 @@ abstract class Settings {
     abstract var overlayApp: String
     abstract var overlayAppNewTask: Boolean
     abstract var autoReloadSnapshot: Boolean
+    abstract var ignoreXposedWarnings: Boolean
 
     abstract fun toRemoteSettings(): RemoteSettingsHolder
 
@@ -61,6 +62,9 @@ class SettingsImpl(context: Context): Settings() {
         private const val KEY_AUTO_RELOAD_SNAPSHOT = "auto_reload_snapshot"
         private const val DEFAULT_AUTO_RELOAD_SNAPSHOT = true
 
+        private const val KEY_IGNORE_XPOSED_WARNINGS = "ignore_xposed_warnings"
+        private const val DEFAULT_IGNORE_XPOSED_WARNINGS = false
+
         fun getDefaultRemoteSettings(): RemoteSettingsHolder {
             return RemoteSettingsHolder(DEFAULT_OVERLAY_ENABLED, DEFAULT_OVERLAY_MODE, DEFAULT_OVERLAY_BACKGROUND, DEFAULT_USE_MONET, null, DEFAULT_OVERLAY_APP, DEFAULT_OVERLAY_APP_NEW_TASK, DEFAULT_AUTO_RELOAD_SNAPSHOT)
         }
@@ -74,6 +78,7 @@ class SettingsImpl(context: Context): Settings() {
     override var overlayApp by shared(KEY_OVERLAY_APP, DEFAULT_OVERLAY_APP)
     override var overlayAppNewTask by shared(KEY_OVERLAY_APP_NEW_TASK, DEFAULT_OVERLAY_APP_NEW_TASK)
     override var autoReloadSnapshot by shared(KEY_AUTO_RELOAD_SNAPSHOT, DEFAULT_AUTO_RELOAD_SNAPSHOT)
+    override var ignoreXposedWarnings by shared(KEY_IGNORE_XPOSED_WARNINGS, DEFAULT_IGNORE_XPOSED_WARNINGS)
 
     override fun toRemoteSettings(): RemoteSettingsHolder {
         return RemoteSettingsHolder(overlayEnabled, overlayMode, overlayBackground, useMonet, monetColor, overlayApp, overlayAppNewTask, autoReloadSnapshot)

--- a/app/src/main/java/com/kieronquinn/app/discoverkiller/ui/screens/overlay/applauncher/AppLauncherOverlay.kt
+++ b/app/src/main/java/com/kieronquinn/app/discoverkiller/ui/screens/overlay/applauncher/AppLauncherOverlay.kt
@@ -18,6 +18,7 @@ import com.kieronquinn.app.discoverkiller.model.RemoteSettingsHolder
 import com.kieronquinn.app.discoverkiller.ui.screens.overlay.snapshot.SnapshotOverlay
 import com.kieronquinn.app.discoverkiller.utils.extensions.isAppInstalled
 import com.kieronquinn.app.discoverkiller.utils.extensions.isDarkMode
+import com.kieronquinn.app.discoverkiller.utils.extensions.removeStatusNavBackgroundOnPreDraw
 import com.kieronquinn.monetcompat.core.MonetCompat
 import kotlinx.coroutines.delay
 import org.koin.android.ext.android.get

--- a/app/src/main/java/com/kieronquinn/app/discoverkiller/ui/screens/settings/container/SettingsContainerFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/discoverkiller/ui/screens/settings/container/SettingsContainerFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.libraries.launcherclient.LauncherClient
+import com.kieronquinn.app.discoverkiller.components.settings.Settings
 import com.kieronquinn.app.discoverkiller.components.xposed.XposedSelfHook
 import com.kieronquinn.app.discoverkiller.databinding.FragmentSettingsContainerBinding
 import com.kieronquinn.app.discoverkiller.ui.base.BoundFragment
@@ -12,12 +13,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.withContext
+import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
 class SettingsContainerFragment :
     BoundFragment<FragmentSettingsContainerBinding>(FragmentSettingsContainerBinding::inflate) {
 
     private val settingsViewModel by sharedViewModel<SettingsViewModel>()
+    private val settings by inject<Settings>()
 
     private val launcherClient by lazy {
         LauncherClient(requireActivity(), settingsViewModel, true)
@@ -59,22 +62,6 @@ class SettingsContainerFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         launcherClient.onAttachedToWindow()
-        setupWithXposedDelayIfNeeded()
-    }
-
-    private fun setupWithXposedDelayIfNeeded() = lifecycleScope.launchWhenResumed {
-        //Give time for Xposed hooks to start if needed
-        if(!XposedSelfHook.isXposedHooked()){
-            withContext(Dispatchers.IO) {
-                delay(2000)
-            }
-            setup()
-        }else{
-            setup()
-        }
-    }
-
-    private fun setup(){
         setupViewPager()
         setupShowListener()
         setupReconnectListener()
@@ -82,7 +69,7 @@ class SettingsContainerFragment :
 
     private fun setupViewPager() {
         with(binding.settingsContainerViewpager) {
-            adapter = SettingsContainerPagerAdapter(this@SettingsContainerFragment)
+            adapter = SettingsContainerPagerAdapter(this@SettingsContainerFragment, settings)
             setCurrentItem(1, false)
             registerOnPageChangeCallback(pageChangeCallback)
             isUserInputEnabled = false

--- a/app/src/main/java/com/kieronquinn/app/discoverkiller/ui/screens/settings/container/SettingsContainerPagerAdapter.kt
+++ b/app/src/main/java/com/kieronquinn/app/discoverkiller/ui/screens/settings/container/SettingsContainerPagerAdapter.kt
@@ -2,13 +2,14 @@ package com.kieronquinn.app.discoverkiller.ui.screens.settings.container
 
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.kieronquinn.app.discoverkiller.components.settings.Settings
 import com.kieronquinn.app.discoverkiller.components.xposed.XposedSelfHook
 import com.kieronquinn.app.discoverkiller.ui.screens.settings.error.hookfail.ErrorXposedHookFailFragment
 import com.kieronquinn.app.discoverkiller.ui.screens.settings.error.noxposed.ErrorNoXposedFragment
 import com.kieronquinn.app.discoverkiller.ui.screens.settings.main.SettingsMainFragment
 import com.kieronquinn.app.discoverkiller.utils.extensions.isAppInstalled
 
-class SettingsContainerPagerAdapter(fragment: Fragment): FragmentStateAdapter(fragment) {
+class SettingsContainerPagerAdapter(fragment: Fragment, private val settings: Settings): FragmentStateAdapter(fragment) {
 
     private val isXposedInstalled by lazy {
         fragment.requireContext().packageManager.run {
@@ -22,8 +23,8 @@ class SettingsContainerPagerAdapter(fragment: Fragment): FragmentStateAdapter(fr
         return when(position){
             1 -> {
                 when {
-                    !isXposedInstalled -> ErrorNoXposedFragment()
-                    !XposedSelfHook.isXposedHooked() -> ErrorXposedHookFailFragment()
+                    !settings.ignoreXposedWarnings && !isXposedInstalled -> ErrorNoXposedFragment()
+                    !settings.ignoreXposedWarnings && !XposedSelfHook.isXposedHooked() -> ErrorXposedHookFailFragment()
                     else -> SettingsMainFragment()
                 }
             }

--- a/app/src/main/java/com/kieronquinn/app/discoverkiller/ui/screens/settings/error/errorignore/ErrorIgnoreBottomSheetFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/discoverkiller/ui/screens/settings/error/errorignore/ErrorIgnoreBottomSheetFragment.kt
@@ -1,0 +1,69 @@
+package com.kieronquinn.app.discoverkiller.ui.screens.settings.error.errorignore
+
+import android.os.Bundle
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import androidx.lifecycle.lifecycleScope
+import com.kieronquinn.app.discoverkiller.R
+import com.kieronquinn.app.discoverkiller.databinding.FragmentBottomSheetErrorIgnoreBinding
+import com.kieronquinn.app.discoverkiller.ui.base.BaseBottomSheetFragment
+import com.kieronquinn.monetcompat.extensions.views.applyMonet
+import kotlinx.coroutines.flow.collect
+import org.koin.androidx.viewmodel.ext.android.viewModel
+
+class ErrorIgnoreBottomSheetFragment: BaseBottomSheetFragment<FragmentBottomSheetErrorIgnoreBinding>(FragmentBottomSheetErrorIgnoreBinding::inflate) {
+
+    private val viewModel by viewModel<ErrorIgnoreBottomSheetViewModel>()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupInsets(view)
+        setupMonet()
+        setupCheckbox()
+        setupButtons()
+    }
+
+    private fun setupInsets(view: View){
+        ViewCompat.setOnApplyWindowInsetsListener(view){ _, insets ->
+            val navigationInsets = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
+            val extraPadding = resources.getDimension(R.dimen.padding_16).toInt()
+            view.updatePadding(left = navigationInsets.left, right = navigationInsets.right, bottom = navigationInsets.bottom + extraPadding)
+            insets
+        }
+    }
+
+    private fun setupMonet() = with(binding) {
+        errorIgnoreCheckbox.applyMonet()
+        errorIgnoreContinue.setTextColor(monet.getAccentColor(requireContext()))
+        errorIgnoreCancel.setTextColor(monet.getAccentColor(requireContext()))
+    }
+
+    private fun setupButtons(){
+        binding.errorIgnoreCancel.setOnClickListener {
+            dismiss()
+        }
+        binding.errorIgnoreContinue.setOnClickListener {
+            viewModel.onContinueClicked(it.context)
+        }
+        lifecycleScope.launchWhenResumed {
+            viewModel.continueChecked.collect {
+                binding.errorIgnoreContinue.isClickable = it
+                binding.errorIgnoreContinue.alpha = if(it) 1.0f else 0.5f
+            }
+        }
+    }
+
+    private fun setupCheckbox() = with(binding.errorIgnoreCheckbox) {
+        setOnClickListener {
+            viewModel.onCheckboxClicked()
+        }
+        lifecycleScope.launchWhenResumed {
+            viewModel.continueChecked.collect {
+                isChecked = it
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/kieronquinn/app/discoverkiller/ui/screens/settings/error/errorignore/ErrorIgnoreBottomSheetViewModel.kt
+++ b/app/src/main/java/com/kieronquinn/app/discoverkiller/ui/screens/settings/error/errorignore/ErrorIgnoreBottomSheetViewModel.kt
@@ -1,0 +1,40 @@
+package com.kieronquinn.app.discoverkiller.ui.screens.settings.error.errorignore
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.jakewharton.processphoenix.ProcessPhoenix
+import com.kieronquinn.app.discoverkiller.components.settings.Settings
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+abstract class ErrorIgnoreBottomSheetViewModel: ViewModel() {
+
+    abstract val continueChecked: Flow<Boolean>
+
+    abstract fun onCheckboxClicked()
+    abstract fun onContinueClicked(context: Context)
+
+}
+
+class ErrorIgnoreBottomSheetViewModelImpl(private val settings: Settings): ErrorIgnoreBottomSheetViewModel() {
+
+    private val _continueChecked = MutableStateFlow(false)
+    override val continueChecked = _continueChecked.asStateFlow()
+
+    override fun onCheckboxClicked() {
+        viewModelScope.launch {
+            _continueChecked.emit(!_continueChecked.value)
+        }
+    }
+
+    override fun onContinueClicked(context: Context) {
+        viewModelScope.launch {
+            settings.ignoreXposedWarnings = true
+            ProcessPhoenix.triggerRebirth(context)
+        }
+    }
+
+}

--- a/app/src/main/java/com/kieronquinn/app/discoverkiller/ui/screens/settings/error/hookfail/ErrorXposedHookFailFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/discoverkiller/ui/screens/settings/error/hookfail/ErrorXposedHookFailFragment.kt
@@ -3,25 +3,50 @@ package com.kieronquinn.app.discoverkiller.ui.screens.settings.error.hookfail
 import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.WindowInsetsControllerCompat
+import com.google.android.material.button.MaterialButton
 import com.jakewharton.processphoenix.ProcessPhoenix
 import com.kieronquinn.app.discoverkiller.databinding.FragmentErrorHookingBinding
 import com.kieronquinn.app.discoverkiller.ui.base.BoundFragment
+import com.kieronquinn.app.discoverkiller.ui.screens.settings.error.errorignore.ErrorIgnoreBottomSheetFragment
+import com.kieronquinn.app.discoverkiller.utils.extensions.isDarkMode
 import com.kieronquinn.monetcompat.extensions.views.overrideRippleColor
 
 class ErrorXposedHookFailFragment: BoundFragment<FragmentErrorHookingBinding>(FragmentErrorHookingBinding::inflate) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        setupStatusNav()
         view.setBackgroundColor(monet.getBackgroundColor(requireContext()))
         with(binding.errorHookingRetry){
-            val accentColor = monet.getAccentColor(requireContext())
-            strokeColor = ColorStateList.valueOf(accentColor)
-            setTextColor(accentColor)
-            overrideRippleColor(accentColor)
+            setup()
             setOnClickListener {
                 ProcessPhoenix.triggerRebirth(requireContext())
             }
         }
+        with(binding.errorHookingIgnore){
+            setup()
+            setOnClickListener {
+                ErrorIgnoreBottomSheetFragment().show(childFragmentManager, "bs_ignore")
+            }
+        }
+    }
+
+    private fun setupStatusNav(){
+        val window = requireActivity().window
+        window.decorView.post {
+            WindowInsetsControllerCompat(window, window.decorView).run {
+                isAppearanceLightNavigationBars = !requireContext().isDarkMode
+                isAppearanceLightStatusBars = !requireContext().isDarkMode
+            }
+        }
+    }
+
+    private fun MaterialButton.setup(){
+        val accentColor = monet.getAccentColor(requireContext())
+        strokeColor = ColorStateList.valueOf(accentColor)
+        setTextColor(accentColor)
+        overrideRippleColor(accentColor)
     }
 
 }

--- a/app/src/main/java/com/kieronquinn/app/discoverkiller/ui/screens/settings/error/noxposed/ErrorNoXposedFragment.kt
+++ b/app/src/main/java/com/kieronquinn/app/discoverkiller/ui/screens/settings/error/noxposed/ErrorNoXposedFragment.kt
@@ -3,9 +3,13 @@ package com.kieronquinn.app.discoverkiller.ui.screens.settings.error.noxposed
 import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.View
+import androidx.core.view.WindowInsetsControllerCompat
+import com.google.android.material.button.MaterialButton
 import com.jakewharton.processphoenix.ProcessPhoenix
 import com.kieronquinn.app.discoverkiller.databinding.FragmentErrorNoXposedBinding
 import com.kieronquinn.app.discoverkiller.ui.base.BoundFragment
+import com.kieronquinn.app.discoverkiller.ui.screens.settings.error.errorignore.ErrorIgnoreBottomSheetFragment
+import com.kieronquinn.app.discoverkiller.utils.extensions.isDarkMode
 import com.kieronquinn.monetcompat.extensions.views.overrideRippleColor
 
 class ErrorNoXposedFragment: BoundFragment<FragmentErrorNoXposedBinding>(FragmentErrorNoXposedBinding::inflate) {
@@ -13,15 +17,36 @@ class ErrorNoXposedFragment: BoundFragment<FragmentErrorNoXposedBinding>(Fragmen
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         view.setBackgroundColor(monet.getBackgroundColor(requireContext()))
+        setupStatusNav()
         with(binding.errorNoXposedRetry){
-            val accentColor = monet.getAccentColor(requireContext())
-            strokeColor = ColorStateList.valueOf(accentColor)
-            setTextColor(accentColor)
-            overrideRippleColor(accentColor)
+            setup()
             setOnClickListener {
                 ProcessPhoenix.triggerRebirth(requireContext())
             }
         }
+        with(binding.errorNoXposedIgnore){
+            setup()
+            setOnClickListener {
+                ErrorIgnoreBottomSheetFragment().show(childFragmentManager, "bs_ignore")
+            }
+        }
+    }
+
+    private fun setupStatusNav(){
+        val window = requireActivity().window
+        window.decorView.post {
+            WindowInsetsControllerCompat(window, window.decorView).run {
+                isAppearanceLightNavigationBars = !requireContext().isDarkMode
+                isAppearanceLightStatusBars = !requireContext().isDarkMode
+            }
+        }
+    }
+
+    private fun MaterialButton.setup(){
+        val accentColor = monet.getAccentColor(requireContext())
+        strokeColor = ColorStateList.valueOf(accentColor)
+        setTextColor(accentColor)
+        overrideRippleColor(accentColor)
     }
 
     override fun onStop() {

--- a/app/src/main/res/layout/fragment_bottom_sheet_error_ignore.xml
+++ b/app/src/main/res/layout/fragment_bottom_sheet_error_ignore.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:animateLayoutChanges="true"
+    tools:layout_gravity="bottom">
+
+    <TextView
+        android:id="@+id/error_ignore_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/padding_16"
+        android:paddingTop="@dimen/padding_8"
+        android:paddingBottom="@dimen/padding_8"
+        android:text="@string/bottom_sheet_error_ignore_title"
+        android:textAppearance="@style/TextAppearance.AppCompat.Large.DiscoverKiller"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/error_ignore_content"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/padding_16"
+        android:text="@string/bottom_sheet_error_ignore_content"
+        android:textAppearance="@style/TextAppearance.AppCompat.Small.DiscoverKiller"
+        app:layout_constraintBottom_toTopOf="@id/error_ignore_checkbox"
+        app:layout_constraintTop_toBottomOf="@id/error_ignore_title" />
+
+    <com.google.android.material.checkbox.MaterialCheckBox
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/error_ignore_checkbox"
+        android:padding="@dimen/padding_16"
+        app:layout_constraintTop_toBottomOf="@id/error_ignore_content"
+        app:layout_constraintBottom_toTopOf="@id/error_ignore_continue"
+        android:text="@string/bottom_sheet_error_ignore_checkbox"
+        android:layout_marginStart="@dimen/padding_8"
+        android:layout_marginEnd="@dimen/padding_8"
+        android:textAppearance="@style/TextAppearance.AppCompat.Small.DiscoverKiller.Bold" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/error_ignore_continue"
+        style="@style/Widget.AppCompat.Button.Borderless.Colored"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/padding_8"
+        android:layout_marginEnd="@dimen/padding_16"
+        android:fontFamily="@font/google_sans_text_medium"
+        android:text="@string/bottom_sheet_error_ignore_continue"
+        android:textAllCaps="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/error_ignore_checkbox" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/error_ignore_cancel"
+        style="@style/Widget.AppCompat.Button.Borderless.Colored"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/padding_8"
+        android:layout_marginEnd="@dimen/padding_16"
+        android:fontFamily="@font/google_sans_text_medium"
+        android:text="@android:string/cancel"
+        android:textAllCaps="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/error_ignore_continue"
+        app:layout_constraintTop_toBottomOf="@id/error_ignore_checkbox" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_error_hooking.xml
+++ b/app/src/main/res/layout/fragment_error_hooking.xml
@@ -47,10 +47,24 @@
         android:minWidth="150dp"
         android:text="@string/error_retry"
         android:textAppearance="@style/TextAppearance.AppCompat.Small.DiscoverKiller.Bold"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/error_hooking_ignore"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/error_hooking_fail_desc"
+        app:strokeWidth="2dp" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/error_hooking_ignore"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minWidth="150dp"
+        android:text="@string/error_ignore"
+        android:textAppearance="@style/TextAppearance.AppCompat.Small.DiscoverKiller.Bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/error_hooking_retry"
         app:strokeWidth="2dp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_error_no_xposed.xml
+++ b/app/src/main/res/layout/fragment_error_no_xposed.xml
@@ -47,10 +47,24 @@
         android:minWidth="150dp"
         android:text="@string/error_retry"
         android:textAppearance="@style/TextAppearance.AppCompat.Small.DiscoverKiller.Bold"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/error_no_xposed_ignore"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/error_no_xposed_desc"
+        app:strokeWidth="2dp" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/error_no_xposed_ignore"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minWidth="150dp"
+        android:text="@string/error_ignore"
+        android:textAppearance="@style/TextAppearance.AppCompat.Small.DiscoverKiller.Bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/error_no_xposed_retry"
         app:strokeWidth="2dp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,4 +64,9 @@
     <string name="bottom_sheet_dump_logs_content">This will save some of the logs related to the overlay, if they exist. You must choose a location to save to. If asked, please attach the log file to your XDA reply or GitHub issue.</string>
     <string name="bottom_sheet_dump_logs_result_success">Dump complete</string>
     <string name="bottom_sheet_dump_logs_result_failed">Dump failed</string>
+    <string name="bottom_sheet_error_ignore_title">Warning</string>
+    <string name="bottom_sheet_error_ignore_content">Discover Killer will <b>not</b> work without a working Xposed installation. You can skip the checks at your own risk, but please do not report issues related to the overlay not working if your Xposed installation is non-functional.</string>
+    <string name="bottom_sheet_error_ignore_continue">Continue</string>
+    <string name="bottom_sheet_error_ignore_checkbox">I understand</string>
+    <string name="error_ignore">Ignore</string>
 </resources>


### PR DESCRIPTION
- Tweaked Material You theming on Snapshot, with colors now applied to the FAB, bottom pill and some icons. Cards are handled from the server so can't be tinted easily.
- Allowed Snapshot to draw behind the status bar and added padding to handle that
- Added the ability to bypass the Xposed checks, please only use this if your Xposed install is working but the checks are failing.
- Improved the hiding of status bar backgrounds to prevent a grey line appearing on Snapshot